### PR TITLE
Fix Expo app entry file path

### DIFF
--- a/mobile/package.json
+++ b/mobile/package.json
@@ -2,7 +2,7 @@
   "name": "rag-portfolio-mobile",
   "version": "1.0.0",
   "description": "RAG-Driven Investment Portfolio Mobile App",
-  "main": "index.js",
+  "main": "App.js",
   "scripts": {
     "start": "expo start",
     "android": "expo start --android",


### PR DESCRIPTION
## Summary
- point Expo app `main` field to existing `App.js`

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa6ff11c68833199219c8528424bcf