### PR TITLE
chore: add Expo app configuration

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -1,0 +1,8 @@
+{
+  "expo": {
+    "name": "rag-portfolio-mobile",
+    "slug": "rag-portfolio-mobile",
+    "version": "1.0.0",
+    "entryPoint": "./App.js"
+  }
+}


### PR DESCRIPTION
## Summary
- add Expo app.json so Expo can locate the entry point

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68aa78189e548331b967e7e2401274ca