### PR TITLE
fix: register Expo root component

### DIFF
--- a/mobile/App.js
+++ b/mobile/App.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { registerRootComponent } from 'expo';
 import {
   SafeAreaView,
   ScrollView,
@@ -449,4 +450,6 @@ const styles = StyleSheet.create({
   },
 });
 
-export default App; 
+registerRootComponent(App);
+
+export default App;


### PR DESCRIPTION
## Summary
- register root component in Expo-based mobile app to resolve "main has not been registered" error

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aa7a7fad948331902132bc53946be1