### PR TITLE
fix: register root component and polyfill URL

### DIFF
--- a/mobile/App.js
+++ b/mobile/App.js
@@ -449,4 +449,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default App; 
+export default App;

--- a/mobile/index.js
+++ b/mobile/index.js
@@ -1,0 +1,21 @@
+(function () {
+  try {
+    const test = new URL('http://example.com');
+    if (typeof test.protocol !== 'string') {
+      throw new Error('protocol not implemented');
+    }
+  } catch (e) {
+    global.URL = class URLPolyfill {
+      constructor(url) {
+        this.href = url;
+        const match = String(url).match(/^([a-z0-9.+-]+:)/i);
+        this.protocol = match ? match[1] : '';
+      }
+    };
+  }
+})();
+
+const { registerRootComponent } = require('expo');
+const App = require('./App').default;
+
+registerRootComponent(App);

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -2,7 +2,7 @@
   "name": "rag-portfolio-mobile",
   "version": "1.0.0",
   "description": "RAG-Driven Investment Portfolio Mobile App",
-  "main": "./App.js",
+  "main": "./index.js",
   "scripts": {
     "start": "expo start",
     "android": "expo start --android",


### PR DESCRIPTION
## Summary
- register root component in new `index.js` entry file
- polyfill minimal `URL` implementation to avoid Hermes protocol error
- update package entry point to `index.js`

## Testing
- `npm test` (fails: Missing script "test")
- `npm test` from repo root (fails: package.json not found)


------
https://chatgpt.com/codex/tasks/task_e_68aa7a7fad948331902132bc53946be1