### PR TITLE
Link chunks to articles using stored Supabase IDs

### DIFF
--- a/app/data_ingestion.py
+++ b/app/data_ingestion.py
@@ -231,8 +231,8 @@ class DataIngestion:
         for article in unique_articles:
             article_hash = hash_article(article.url, article.title, article.published_at)
             if not get_article_by_hash(article_hash):
-                # Insert into Supabase
-                upsert_article({
+                # Insert into Supabase and capture returned row to obtain article ID
+                inserted = upsert_article({
                     "url": article.url,
                     "title": article.title,
                     "published_at": article.published_at,
@@ -240,6 +240,9 @@ class DataIngestion:
                     "industry": article.industry,
                     "article_hash": article_hash
                 })
+                # Store the Supabase-generated ID on the article for linking chunks
+                if inserted and inserted.get("id") is not None:
+                    article.id = inserted["id"]
                 new_articles.append(article)
             else:
                 logger.info(f"Article already in Supabase: {article.url}")

--- a/app/models.py
+++ b/app/models.py
@@ -37,6 +37,8 @@ class InvestmentIdeasResponse(BaseModel):
     generated_at: str
 
 class NewsArticle(BaseModel):
+    """Representation of a news article fetched from external sources or Supabase."""
+    id: Optional[int] = None
     title: str
     content: str
     url: str

--- a/app/text_processor.py
+++ b/app/text_processor.py
@@ -125,9 +125,9 @@ class TextProcessor:
             chunk_tickers = self.extract_tickers_from_text(chunk)
             if chunk_tickers:
                 metadata['chunk_tickers'] = chunk_tickers
-            # Insert chunk into Supabase
+            # Insert chunk into Supabase, linking to the article if an ID is available
             upsert_chunk({
-                "article_id": None,  # Optionally link to article if you fetch it
+                "article_id": getattr(article, "id", None),
                 "chunk_index": i,
                 "content": chunk,
                 "chunk_hash": chunk_hash,


### PR DESCRIPTION
## Summary
- Track Supabase-generated article IDs in `NewsArticle`
- Store the ID during ingestion for new articles
- Attach `article_id` to chunks when saving so records can be linked

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa86fa79cc833191012f35e8b4f344