### PR TITLE
Link chunks to articles using stored Supabase IDs

### DIFF
--- a/app/data_ingestion.py
+++ b/app/data_ingestion.py
@@ -16,7 +16,13 @@ import logging
 from .models import NewsArticle
 from .config_manager import config_manager
 from .supabase_client import (
-    hash_article, hash_chunk, get_article_by_hash, upsert_article, get_chunk_by_hash, upsert_chunk
+    hash_article,
+    hash_chunk,
+    get_article_by_hash,
+    upsert_article,
+    get_chunk_by_hash,
+    upsert_chunk,
+    article_has_chunks,
 )
 
 logging.basicConfig(level=logging.INFO)
@@ -230,9 +236,10 @@ class DataIngestion:
         new_articles = []
         for article in unique_articles:
             article_hash = hash_article(article.url, article.title, article.published_at)
-            if not get_article_by_hash(article_hash):
-                # Insert into Supabase
-                upsert_article({
+            existing = get_article_by_hash(article_hash)
+            if not existing:
+                # Insert into Supabase and capture returned row to obtain article ID
+                inserted = upsert_article({
                     "url": article.url,
                     "title": article.title,
                     "published_at": article.published_at,
@@ -240,9 +247,17 @@ class DataIngestion:
                     "industry": article.industry,
                     "article_hash": article_hash
                 })
+                # Store the Supabase-generated ID on the article for linking chunks
+                if inserted and inserted.get("id") is not None:
+                    article.id = inserted["id"]
                 new_articles.append(article)
             else:
-                logger.info(f"Article already in Supabase: {article.url}")
+                # If the article exists but has no chunks, process it again
+                if not article_has_chunks(existing["id"]):
+                    article.id = existing["id"]
+                    new_articles.append(article)
+                else:
+                    logger.info(f"Article already in Supabase: {article.url}")
         
         logger.info(f"{len(new_articles)} new articles to process (not in Supabase)")
         return new_articles

--- a/app/models.py
+++ b/app/models.py
@@ -37,6 +37,8 @@ class InvestmentIdeasResponse(BaseModel):
     generated_at: str
 
 class NewsArticle(BaseModel):
+    """Representation of a news article fetched from external sources or Supabase."""
+    id: Optional[int] = None
     title: str
     content: str
     url: str

--- a/app/supabase_client.py
+++ b/app/supabase_client.py
@@ -30,6 +30,11 @@ def upsert_article(article: Dict[str, Any]) -> Dict[str, Any]:
     res = supabase.table("articles").upsert(article).execute()
     return res.data[0] if res.data else None
 
+def article_has_chunks(article_id: int) -> bool:
+    """Check if any chunks exist for the given article ID."""
+    res = supabase.table("chunks").select("id").eq("article_id", article_id).limit(1).execute()
+    return bool(res.data)
+
 # --- Chunk helpers ---
 def get_chunk_by_hash(chunk_hash: str) -> Optional[Dict[str, Any]]:
     res = supabase.table("chunks").select("*").eq("chunk_hash", chunk_hash).execute()

--- a/app/text_processor.py
+++ b/app/text_processor.py
@@ -125,9 +125,9 @@ class TextProcessor:
             chunk_tickers = self.extract_tickers_from_text(chunk)
             if chunk_tickers:
                 metadata['chunk_tickers'] = chunk_tickers
-            # Insert chunk into Supabase
+            # Insert chunk into Supabase, linking to the article if an ID is available
             upsert_chunk({
-                "article_id": None,  # Optionally link to article if you fetch it
+                "article_id": getattr(article, "id", None),
                 "chunk_index": i,
                 "content": chunk,
                 "chunk_hash": chunk_hash,


### PR DESCRIPTION
## Summary
- Track Supabase-generated article IDs in `NewsArticle`
- Store the ID during ingestion for new articles
- Attach `article_id` to chunks when saving so records can be linked
- Reprocess previously ingested articles that lack chunks

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa86fa79cc833191012f35e8b4f344