### PR TITLE
Handle chunkless articles in Supabase

### DIFF
--- a/app/data_ingestion.py
+++ b/app/data_ingestion.py
@@ -18,7 +18,7 @@ import logging
 from .models import NewsArticle
 from .config_manager import config_manager
 from .supabase_client import (
-	hash_article, hash_chunk, get_article_by_hash, upsert_article, get_chunk_by_hash, upsert_chunk
+        hash_article, hash_chunk, get_article_by_hash, upsert_article, get_chunk_by_hash, upsert_chunk, article_has_chunks
 )
 
 logging.basicConfig(level=logging.INFO)
@@ -257,32 +257,39 @@ class DataIngestion:
 		logger.info(f"Fetched {len(unique_articles)} unique articles")
 		
 		# --- Supabase persistent cache: filter out already-processed articles ---
-		new_articles = []
-		for article in unique_articles:
-			article_hash = hash_article(article.url, article.title, article.published_at)
-			if not get_article_by_hash(article_hash):
-				# Insert into Supabase
-				upsert_article({
-					"url": article.url,
-					"title": article.title,
-					"published_at": article.published_at,
-					"source": article.source,
-					"industry": article.industry,
-					"article_hash": article_hash
-				})
-				new_articles.append(article)
-			else:
-				logger.info(f"Article already in Supabase: {article.url}")
-		
-		logger.info(f"{len(new_articles)} new articles to process (not in Supabase)")
-		return new_articles
+                new_articles = []
+                for article in unique_articles:
+                        article_hash = hash_article(article.url, article.title, article.published_at)
+                        existing = get_article_by_hash(article_hash)
+                        if not existing:
+                                stored = upsert_article({
+                                        "url": article.url,
+                                        "title": article.title,
+                                        "published_at": article.published_at,
+                                        "source": article.source,
+                                        "industry": article.industry,
+                                        "article_hash": article_hash
+                                })
+                                if stored:
+                                        article.id = stored.get("id")
+                                new_articles.append(article)
+                        else:
+                                article.id = existing.get("id")
+                                if article.id and not article_has_chunks(article.id):
+                                        logger.info(f"Article in Supabase without chunks: {article.url}")
+                                        new_articles.append(article)
+                                else:
+                                        logger.info(f"Article already in Supabase: {article.url}")
 
-	def clean_text(self, text: str) -> str:
-		"""Clean and standardize text"""
-		# Remove extra whitespace
-		text = re.sub(r'\s+', ' ', text)
-		# Remove special characters but keep basic punctuation
-		text = re.sub(r'[^\w\s\.\,\!\?\-\:\;]', '', text)
-		# Standardize to lowercase
-		text = text.lower().strip()
-		return text 
+                logger.info(f"{len(new_articles)} new articles to process (including reprocessing)")
+                return new_articles
+
+        def clean_text(self, text: str) -> str:
+                """Clean and standardize text"""
+                # Remove extra whitespace
+                text = re.sub(r'\s+', ' ', text)
+                # Remove special characters but keep basic punctuation
+                text = re.sub(r'[^\w\s\.\,\!\?\-\:\;]', '', text)
+                # Standardize to lowercase
+                text = text.lower().strip()
+                return text

--- a/app/models.py
+++ b/app/models.py
@@ -37,6 +37,7 @@ class InvestmentIdeasResponse(BaseModel):
     generated_at: str
 
 class NewsArticle(BaseModel):
+    id: Optional[int] = None
     title: str
     content: str
     url: str
@@ -48,4 +49,4 @@ class NewsArticle(BaseModel):
 class ProcessedChunk(BaseModel):
     content: str
     metadata: dict
-    embedding: Optional[List[float]] = None 
+    embedding: Optional[List[float]] = None

--- a/app/supabase_client.py
+++ b/app/supabase_client.py
@@ -88,8 +88,15 @@ def get_chunks_for_ticker(ticker: str, since: str = None) -> List[Dict[str, Any]
 	return res.data or []
 
 def get_articles_for_day(day: str) -> List[Dict[str, Any]]:
-	# day: 'YYYY-MM-DD'
-	if not supabase:
-		return []
-	res = supabase.table("articles").select("*").gte("published_at", f"{day}T00:00:00Z").lt("published_at", f"{day}T23:59:59Z").execute()
-	return res.data or [] 
+    # day: 'YYYY-MM-DD'
+    if not supabase:
+        return []
+    res = supabase.table("articles").select("*").gte("published_at", f"{day}T00:00:00Z").lt("published_at", f"{day}T23:59:59Z").execute()
+    return res.data or []
+
+def article_has_chunks(article_id: int) -> bool:
+    """Check if an article already has chunks stored"""
+    if not supabase:
+        return False
+    res = supabase.table("chunks").select("id").eq("article_id", article_id).limit(1).execute()
+    return bool(res.data)

--- a/app/text_processor.py
+++ b/app/text_processor.py
@@ -126,14 +126,16 @@ class TextProcessor:
             if chunk_tickers:
                 metadata['chunk_tickers'] = ','.join(chunk_tickers)
             # Insert chunk into Supabase
-            upsert_chunk({
-                "article_id": article.id,  # Link to the article using the correct foreign key
+            chunk_record = {
                 "chunk_index": i,
                 "content": chunk,
                 "chunk_hash": chunk_hash,
                 "embedding": None,  # To be filled after embedding
                 "metadata": metadata
-            })
+            }
+            if article.id is not None:
+                chunk_record["article_id"] = article.id
+            upsert_chunk(chunk_record)
             processed_chunks.append(ProcessedChunk(
                 content=chunk,
                 metadata=metadata
@@ -180,5 +182,6 @@ class TextProcessor:
                 logger.error(f"Error parsing date for chunk: {e}")
                 # Include chunks with date parsing errors
                 filtered_chunks.append(chunk)
-        
-        return filtered_chunks 
+
+        return filtered_chunks
+


### PR DESCRIPTION
## Summary
- store Supabase article IDs on `NewsArticle`
- re-ingest articles missing chunks by checking Supabase
- add `article_has_chunks` helper and link chunks to article IDs when available

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aabe3e02b8833198cb3b71a2b0dad0